### PR TITLE
Fix "Unable to locate a class or view for component [modal]."

### DIFF
--- a/content/docs/guides/using-filament-with-volt.md
+++ b/content/docs/guides/using-filament-with-volt.md
@@ -328,7 +328,7 @@ We can simplify the process of viewing, creating, editing, and deleting our proj
         <x-app.container class="max-w-5xl">
             <div class="flex items-center justify-between mb-5">
                 <x-app.heading title="Projects" description="Check out your projects below" :border="false"/>
-                <x-modal id="create-project" width="md" :slide-over="true">
+                <x-filament::modal id="create-project" width="md" :slide-over="true">
                     <x-slot name="trigger">
                         <x-button>New Project</x-button>
                     </x-slot>


### PR DESCRIPTION
The sample in the documentation does not work as is. The author's intention was clearly to use Filament's built-in modal component `<x-filament::modal `. Fixed and tested ✅